### PR TITLE
Support Integer literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ end
 
 ## Available types
 
-| Type    | Description                         |
-| ------- | ----------------------------------- |
-| integer | The value must be casted to Integer |
+| Type                        | Description                         | Example               |
+| --------------------------- | ----------------------------------- | --------------------- |
+| integer                     | The value must be casted to Integer | `let :stock, integer` |
+| 1, 2, ... (Integer literal) | The value must be casted to Integer | `let :id, 3`          |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ end
 
 ## Available types
 
-| Type                        | Description                         | Example               |
-| --------------------------- | ----------------------------------- | --------------------- |
-| integer                     | The value must be casted to Integer | `let :stock, integer` |
-| 1, 2, ... (Integer literal) | The value must be casted to Integer | `let :id, 3`          |
+| Type                        | Description                                  | Example               |
+| --------------------------- | -------------------------------------------- | --------------------- |
+| integer                     | The value must be casted to Integer          | `let :stock, integer` |
+| 1, 2, ... (Integer literal) | The value must be casted to specific Integer | `let :id, 3`          |
 
 ## Contributing
 

--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -8,6 +8,7 @@ require_relative "strong_csv/let"
 require_relative "strong_csv/value_result"
 require_relative "strong_csv/types/base"
 require_relative "strong_csv/types/integer"
+require_relative "strong_csv/types/literal"
 require_relative "strong_csv/row"
 
 # The top-level namespace for the strong_csv gem.

--- a/lib/strong_csv/row.rb
+++ b/lib/strong_csv/row.rb
@@ -4,6 +4,7 @@ class StrongCSV
   # Row is a representation of a row in a CSV file, which has casted values with specified types.
   class Row
     extend Forwardable
+    using Types::Literal
 
     def_delegators :@values, :[], :fetch
 

--- a/lib/strong_csv/types/integer.rb
+++ b/lib/strong_csv/types/integer.rb
@@ -5,6 +5,8 @@ class StrongCSV
     # Integer type
     class Integer < Base
       # @todo Use :exception for Integer after we drop the support of Ruby 2.5
+      # @param value [Object] Value to be casted to Integer
+      # @return [ValueResult]
       def cast(value)
         ValueResult.new(value: Integer(value), original_value: value)
       rescue ArgumentError, TypeError

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -13,7 +13,7 @@ class StrongCSV
           if int == self
             ValueResult.new(value: int, original_value: value)
           else
-            ValueResult.new(original_value: value, error_message: "`#{self.inspect}` is expected, but `#{int}` was given.")
+            ValueResult.new(original_value: value, error_message: "`#{inspect}` is expected, but `#{int}` was given.")
           end
         rescue ArgumentError, TypeError
           ValueResult.new(original_value: value, error_message: "`#{value.inspect}` can't be casted to Integer")

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class StrongCSV
+  module Types
+    # Literal is a module to collect all the literal types for CSV parsing.
+    # This module is intended for refining built-in classes and provide `#cast` like `Base` class.
+    module Literal
+      refine ::Integer do
+        # @param value [Object] Value to be casted to Integer
+        # @return [ValueResult]
+        def cast(value)
+          int = Integer(value)
+          if int == self
+            ValueResult.new(value: int, original_value: value)
+          else
+            ValueResult.new(original_value: value, error_message: "`#{self.inspect}` is expected, but `#{int}` was given.")
+          end
+        rescue ArgumentError, TypeError
+          ValueResult.new(original_value: value, error_message: "`#{value.inspect}` can't be casted to Integer")
+        end
+      end
+    end
+  end
+end

--- a/test/types/literal_integer_test.rb
+++ b/test/types/literal_integer_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class LiteralIntegerTest < Minitest::Test
+  using StrongCSV::Types::Literal
+
+  def test_cast
+    value_result = 123.cast("123")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal 123, value_result.value
+  end
+
+  def test_cast_with_unexpected_value
+    value_result = 8.cast("13")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "13", value_result.value
+    assert_equal "`8` is expected, but `13` was given.", value_result.error_message
+  end
+
+  def test_cast_with_error
+    value_result = 8.cast("1.3")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "1.3", value_result.value
+    assert_equal '`"1.3"` can\'t be casted to Integer', value_result.error_message
+  end
+
+  def test_cast_with_nil_error
+    value_result = 31.cast(nil)
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_nil value_result.value
+    assert_equal "`nil` can't be casted to Integer", value_result.error_message
+  end
+
+  def test_initialize_without_headers
+    strong_csv = StrongCSV.new do
+      let 0, 40
+    end
+    strong_csv.parse("40") do |row|
+      assert_instance_of StrongCSV::Row, row
+      assert row.valid?
+      assert_equal 40, row[0]
+    end
+  end
+
+  def test_initialize_with_headers
+    strong_csv = StrongCSV.new do
+      let :id, 4
+    end
+    data = <<~CSV
+      id
+      4,5,6
+    CSV
+    strong_csv.parse(data) do |row|
+      assert_instance_of StrongCSV::Row, row
+      assert row.valid?
+      assert_equal 4, row[:id]
+    end
+  end
+
+  def test_int_with_negative_value
+    strong_csv = StrongCSV.new do
+      let :id, -4
+    end
+    data = <<~CSV
+      id
+      -4
+    CSV
+    strong_csv.parse(data) do |row|
+      assert_instance_of StrongCSV::Row, row
+      assert row.valid?
+      assert_equal(-4, row[:id])
+    end
+  end
+
+  def test_int_with_hex_value
+    strong_csv = StrongCSV.new do
+      let :id, 0x12
+    end
+    result = strong_csv.parse(<<~CSV)
+      id
+      0x12
+      0x12
+    CSV
+    assert result.all?(&:valid?)
+    assert_equal([0x12, 0x12], result.map { |row| row[:id] })
+  end
+
+  def test_int_with_octal_value
+    strong_csv = StrongCSV.new do
+      let :id, 0o12
+    end
+    result = strong_csv.parse(<<~CSV)
+      id
+      0o12
+    CSV
+    assert result.all?(&:valid?)
+    assert_equal([0o12], result.map { |row| row[:id] })
+  end
+
+  def test_int_with_float_value
+    strong_csv = StrongCSV.new do
+      let :id, 80
+    end
+    result = strong_csv.parse(<<~CSV)
+      id
+      4.5
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["4.5"], result.map { |row| row[:id] })
+  end
+
+  def test_int_with_non_numeric_value
+    strong_csv = StrongCSV.new do
+      let :id, 80
+    end
+    result = strong_csv.parse(<<~CSV)
+      id
+      abc
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["abc"], result.map { |row| row[:id] })
+  end
+
+  def test_int_with_null
+    strong_csv = StrongCSV.new do
+      let :id, 80
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      3,
+      ,
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["3", nil], result.map { |row| row[:id] })
+  end
+
+  def test_int_with_blank_value
+    strong_csv = StrongCSV.new do
+      let :id, 80
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      3,
+      " "
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["3", " "], result.map { |row| row[:id] })
+  end
+end


### PR DESCRIPTION
Some systems might require CSV files to be set with exact literals.
This patch introduces the module, `Types::Literal`, and makes it provide
our own custom methods for built-in classes.

The scope of this patch is to support Integer literals, and the users of
this gem can declare specific literals for some columns like this:

```ruby
StrongCSV.new do
  let :foo, 123 # The column `:foo` must be set with `123`
end
```