### PR TITLE
Change #error_message to #error_messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ strong_csv.parse(data, field_size_limit: 2048) do |row|
     row[:active] # => true
     # do something with row
   else
-    row.errors # => [{ row: 2, column: :user_id, messages: ["must be present", "must be an Integer", "must satisfy the custom validation"] }]
+    row.errors # => { user_id: ["must be present", "must be an integer"] }
     # do something with row.errors
   end
 end

--- a/lib/strong_csv/types/integer.rb
+++ b/lib/strong_csv/types/integer.rb
@@ -10,7 +10,7 @@ class StrongCSV
       def cast(value)
         ValueResult.new(value: Integer(value), original_value: value)
       rescue ArgumentError, TypeError
-        ValueResult.new(original_value: value, error_message: "`#{value.inspect}` can't be casted to Integer")
+        ValueResult.new(original_value: value, error_messages: ["`#{value.inspect}` can't be casted to Integer"])
       end
     end
   end

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -13,10 +13,10 @@ class StrongCSV
           if int == self
             ValueResult.new(value: int, original_value: value)
           else
-            ValueResult.new(original_value: value, error_message: "`#{inspect}` is expected, but `#{int}` was given.")
+            ValueResult.new(original_value: value, error_messages: ["`#{inspect}` is expected, but `#{int}` was given."])
           end
         rescue ArgumentError, TypeError
-          ValueResult.new(original_value: value, error_message: "`#{value.inspect}` can't be casted to Integer")
+          ValueResult.new(original_value: value, error_messages: ["`#{value.inspect}` can't be casted to Integer"])
         end
       end
     end

--- a/lib/strong_csv/value_result.rb
+++ b/lib/strong_csv/value_result.rb
@@ -6,13 +6,13 @@ class StrongCSV
     DEFAULT_VALUE = Object.new
     private_constant :DEFAULT_VALUE
 
-    # @return [String, nil] The error message for the field.
-    attr_reader :error_message
+    # @return [Array<String>, nil] The error messages for the field.
+    attr_reader :error_messages
 
-    def initialize(original_value:, value: DEFAULT_VALUE, error_message: nil)
+    def initialize(original_value:, value: DEFAULT_VALUE, error_messages: nil)
       @value = value
       @original_value = original_value
-      @error_message = error_message
+      @error_messages = error_messages
     end
 
     # @return [Object] The casted value if it's valid. Otherwise, returns the original value.
@@ -22,7 +22,7 @@ class StrongCSV
 
     # @return [Boolean]
     def success?
-      @error_message.nil?
+      @error_messages.nil?
     end
   end
 end

--- a/test/value_result_test.rb
+++ b/test/value_result_test.rb
@@ -7,13 +7,13 @@ class ValueResultTest < Minitest::Test
     value_result = StrongCSV::ValueResult.new(value: 123.3, original_value: "123.3")
     assert value_result.success?
     assert_equal 123.3, value_result.value
-    assert_nil value_result.error_message
+    assert_nil value_result.error_messages
   end
 
   def test_initialize_with_error
-    value_result = StrongCSV::ValueResult.new(original_value: "123.3", error_message: "error")
+    value_result = StrongCSV::ValueResult.new(original_value: "123.3", error_messages: ["error"])
     refute value_result.success?
     assert_equal "123.3", value_result.value
-    assert_equal "error", value_result.error_message
+    assert_equal ["error"], value_result.error_messages
   end
 end


### PR DESCRIPTION
I'm planning to add `Union` type and want to hold all error messages of
its subtypes when they all are invalid. So, I changed `#error_message`
to `#error_messages`.

This patch brings breaking changes, but I think it makes sense for the
future implementations.