### PR TITLE
Support Union type

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ gem install strong_csv
 TBD: This hasn't yet been implemented.
 
 ```ruby
+require "strong_csv"
+using StrongCSV::Types::Literal # This is required to use Union types for literal values.
+
 strong_csv = StrongCSV.new do
   let :stock, integer
   let :tax_rate, float
@@ -97,11 +100,12 @@ end
 
 ## Available types
 
-| Type                        | Description                                  | Example                |
-| --------------------------- | -------------------------------------------- | ---------------------- |
-| integer                     | The value must be casted to Integer          | `let :stock, integer`  |
-| boolean                     | The value must be casted to Boolean          | `let :active, boolean` |
-| 1, 2, ... (Integer literal) | The value must be casted to specific Integer | `let :id, 3`           |
+| Type                        | Description                                  | Example                        |
+| --------------------------- | -------------------------------------------- | ------------------------------ |
+| integer                     | The value must be casted to Integer          | `let :stock, integer`          |
+| boolean                     | The value must be casted to Boolean          | `let :active, boolean`         |
+| 1, 2, ... (Integer literal) | The value must be casted to specific Integer | `let :id, 3`                   |
+| &#124; (Union type)         | The value must satisfy one of the subtypes   | `let :id, 1 &#124; 2 &#124; 3` |
 
 ## Contributing
 

--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -5,12 +5,13 @@ require "forwardable"
 require "set"
 
 require_relative "strong_csv/version"
-require_relative "strong_csv/let"
 require_relative "strong_csv/value_result"
 require_relative "strong_csv/types/base"
 require_relative "strong_csv/types/boolean"
 require_relative "strong_csv/types/integer"
 require_relative "strong_csv/types/literal"
+require_relative "strong_csv/types/union"
+require_relative "strong_csv/let"
 require_relative "strong_csv/row"
 
 # The top-level namespace for the strong_csv gem.

--- a/lib/strong_csv/types/base.rb
+++ b/lib/strong_csv/types/base.rb
@@ -7,6 +7,10 @@ class StrongCSV
       def cast(_value)
         raise NotImplementedError
       end
+
+      def |(other)
+        Union.new(self, other)
+      end
     end
   end
 end

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -13,10 +13,14 @@ class StrongCSV
           if int == self
             ValueResult.new(value: int, original_value: value)
           else
-            ValueResult.new(original_value: value, error_messages: ["`#{inspect}` is expected, but `#{int}` was given."])
+            ValueResult.new(original_value: value, error_messages: ["`#{inspect}` is expected, but `#{int}` was given"])
           end
         rescue ArgumentError, TypeError
           ValueResult.new(original_value: value, error_messages: ["`#{value.inspect}` can't be casted to Integer"])
+        end
+
+        def |(other)
+          Union.new(self, other)
         end
       end
     end

--- a/lib/strong_csv/types/union.rb
+++ b/lib/strong_csv/types/union.rb
@@ -9,8 +9,6 @@ class StrongCSV
       # @param left [Base]
       # @param right [Base]
       def initialize(left, right)
-        raise ArgumentError, "`left` and `right` must have #cast." unless left.respond_to?(:cast) && right.respond_to?(:cast)
-
         super()
         @left = left
         @right = right

--- a/lib/strong_csv/types/union.rb
+++ b/lib/strong_csv/types/union.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class StrongCSV
+  module Types
+    # Union type is a type that combine multiple types.
+    class Union < Base
+      using Types::Literal
+
+      # @param left [Base]
+      # @param right [Base]
+      def initialize(left, right)
+        raise ArgumentError, "`left` and `right` must have #cast." unless left.respond_to?(:cast) && right.respond_to?(:cast)
+
+        super()
+        @left = left
+        @right = right
+      end
+
+      # @param value [Object] Value to be casted to Integer
+      # @return [ValueResult]
+      def cast(value)
+        left_result = @left.cast(value)
+        return left_result if left_result.success?
+
+        right_result = @right.cast(value)
+        right_result.success? ? right_result : left_result.tap { |l| l.error_messages.concat(right_result.error_messages).uniq! }
+      end
+    end
+  end
+end

--- a/test/types/boolean_test.rb
+++ b/test/types/boolean_test.rb
@@ -37,7 +37,7 @@ class TypesBooleanTest < Minitest::Test
     end
   end
 
-  def test_initialize_without_headers
+  def test_without_headers
     strong_csv = StrongCSV.new do
       let 0, boolean
       let 1, boolean
@@ -50,7 +50,7 @@ class TypesBooleanTest < Minitest::Test
     end
   end
 
-  def test_initialize_with_headers
+  def test_with_headers
     strong_csv = StrongCSV.new do
       let :id, boolean
     end
@@ -65,7 +65,7 @@ class TypesBooleanTest < Minitest::Test
     end
   end
 
-  def test_int_with_non_boolean_value
+  def test_with_non_boolean_value
     strong_csv = StrongCSV.new do
       let :id, boolean
     end
@@ -78,7 +78,7 @@ class TypesBooleanTest < Minitest::Test
     assert_equal([["`\"abc\"` can't be casted to Boolean"]], result.map { |row| row.errors[:id] })
   end
 
-  def test_int_with_null
+  def test_with_null
     strong_csv = StrongCSV.new do
       let :id, boolean
     end
@@ -92,7 +92,7 @@ class TypesBooleanTest < Minitest::Test
     assert_equal([["`\"3\"` can't be casted to Boolean"], ["`nil` can't be casted to Boolean"]], result.map { |row| row.errors[:id] })
   end
 
-  def test_int_with_blank_value
+  def test_with_blank_value
     strong_csv = StrongCSV.new do
       let :id, boolean
     end

--- a/test/types/integer_test.rb
+++ b/test/types/integer_test.rb
@@ -26,7 +26,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal ["`nil` can't be casted to Integer"], value_result.error_messages
   end
 
-  def test_initialize_without_headers
+  def test_without_headers
     strong_csv = StrongCSV.new do
       let 0, integer
     end
@@ -37,7 +37,7 @@ class TypesIntegerTest < Minitest::Test
     end
   end
 
-  def test_initialize_with_headers
+  def test_with_headers
     strong_csv = StrongCSV.new do
       let :id, integer
     end
@@ -52,7 +52,7 @@ class TypesIntegerTest < Minitest::Test
     end
   end
 
-  def test_int_with_negative_value
+  def test_with_negative_value
     strong_csv = StrongCSV.new do
       let :id, integer
     end
@@ -67,7 +67,7 @@ class TypesIntegerTest < Minitest::Test
     end
   end
 
-  def test_int_with_hex_value
+  def test_with_hex_value
     strong_csv = StrongCSV.new do
       let :id, integer
     end
@@ -80,7 +80,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal([0x12, 123], result.map { |row| row[:id] })
   end
 
-  def test_int_with_octal_value
+  def test_with_octal_value
     strong_csv = StrongCSV.new do
       let :id, integer
     end
@@ -92,7 +92,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal([0o12], result.map { |row| row[:id] })
   end
 
-  def test_int_with_float_value
+  def test_with_float_value
     strong_csv = StrongCSV.new do
       let :id, integer
     end
@@ -104,7 +104,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal(["4.5"], result.map { |row| row[:id] })
   end
 
-  def test_int_with_non_numeric_value
+  def test_with_non_numeric_value
     strong_csv = StrongCSV.new do
       let :id, integer
     end
@@ -116,7 +116,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal(["abc"], result.map { |row| row[:id] })
   end
 
-  def test_int_with_null
+  def test_with_null
     strong_csv = StrongCSV.new do
       let :id, integer
     end
@@ -129,7 +129,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal([3, nil], result.map { |row| row[:id] })
   end
 
-  def test_int_with_blank_value
+  def test_with_blank_value
     strong_csv = StrongCSV.new do
       let :id, integer
     end

--- a/test/types/literal_integer_test.rb
+++ b/test/types/literal_integer_test.rb
@@ -17,7 +17,7 @@ class LiteralIntegerTest < Minitest::Test
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?
     assert_equal "13", value_result.value
-    assert_equal ["`8` is expected, but `13` was given."], value_result.error_messages
+    assert_equal ["`8` is expected, but `13` was given"], value_result.error_messages
   end
 
   def test_cast_with_error

--- a/test/types/union_test.rb
+++ b/test/types/union_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class TypesIntegerTest < Minitest::Test
+  using StrongCSV::Types::Literal
+
+  def test_cast
+    value_result = StrongCSV::Types::Union.new(12, 3).cast("3")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal 3, value_result.value
+  end
+
+  def test_cast_with_error
+    value_result = StrongCSV::Types::Union.new(10, 8).cast("1.3")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "1.3", value_result.value
+    assert_equal ['`"1.3"` can\'t be casted to Integer'], value_result.error_messages
+  end
+
+  def test_cast_with_nil_error
+    value_result = StrongCSV::Types::Union.new(10, 11).cast(nil)
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_nil value_result.value
+    assert_equal ["`nil` can't be casted to Integer"], value_result.error_messages
+  end
+
+  def test_cast_with_error_of_multiple_types
+    value_result = StrongCSV::Types::Union.new(10, StrongCSV::Types::Boolean.new).cast(nil)
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_nil value_result.value
+    assert_equal ["`nil` can't be casted to Integer", "`nil` can't be casted to Boolean"], value_result.error_messages
+  end
+
+  def test_with_multiple_values
+    strong_csv = StrongCSV.new do
+      let 0, integer | boolean
+    end
+    result = strong_csv.parse(<<~CSV)
+      123
+      20
+      False
+      0
+      TRUE
+    CSV
+    assert result.all?(&:valid?)
+    assert_equal([123, 20, false, 0, true], result.map { |row| row[0] })
+  end
+
+  def test_with_multiple_values_including_error
+    strong_csv = StrongCSV.new do
+      let :id, integer | boolean
+    end
+    result = strong_csv.parse(<<~CSV)
+      id
+      😇
+      123
+      20
+      False
+      0
+      TRUE
+      1.3
+    CSV
+    assert_equal [false, true, true, true, true, true, false], result.map(&:valid?)
+    assert_equal(["😇", 123, 20, false, 0, true, "1.3"], result.map { |row| row[:id] })
+    assert_equal(
+      [
+        ["`\"😇\"` can't be casted to Integer", "`\"😇\"` can't be casted to Boolean"],
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        ["`\"1.3\"` can't be casted to Integer", "`\"1.3\"` can't be casted to Boolean"]
+      ],
+      result.map { |row| row.errors[:id] }
+    )
+  end
+
+  def test_with_many_multiple_values
+    strong_csv = StrongCSV.new do
+      let 0, 10 | 20 | 30 | 40 | 50
+    end
+    result = strong_csv.parse(<<~CSV)
+      15
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["15"], result.map { |row| row[0] })
+    assert_equal(
+      [
+        [
+          "`10` is expected, but `15` was given",
+          "`20` is expected, but `15` was given",
+          "`30` is expected, but `15` was given",
+          "`40` is expected, but `15` was given",
+          "`50` is expected, but `15` was given"
+        ]
+      ],
+      result.map { |row| row.errors[0] }
+    )
+  end
+end


### PR DESCRIPTION
It would be useful to declare Union types for a CSV field like this:

```ruby
let :foo, 10 | 20 | 30
let :bar, integer | float # NOTE float hasn't been supported yet.
```

This patch introduces `Types::Union` and let developers use it via
bitwise OR operator `|`.

Sorry, this patch also includes breaking changes to the error messages of Integer literals.