### PR TITLE
Change Union syntax from `|` to `,`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ TBD: This hasn't yet been implemented.
 
 ```ruby
 require "strong_csv"
-using StrongCSV::Types::Literal # This is required to use Union types for literal values.
 
 strong_csv = StrongCSV.new do
   let :stock, integer
@@ -55,8 +54,8 @@ strong_csv = StrongCSV.new do
 
   # Literal declaration
   let :status, 0..6
-  let :priority, 10 | 20 | 30 | 40 | 50
-  let :size, "S" | "M" | "L" do |value|
+  let :priority, 10, 20, 30, 40, 50
+  let :size, "S", "M", "L" do |value|
     case value
     when "S"
       1
@@ -105,7 +104,7 @@ end
 | integer                     | The value must be casted to Integer          | `let :stock, integer`  |
 | boolean                     | The value must be casted to Boolean          | `let :active, boolean` |
 | 1, 2, ... (Integer literal) | The value must be casted to specific Integer | `let :id, 3`           |
-| \| (Union type)             | The value must satisfy one of the subtypes   | `let :id, 1 \| 2 \| 3` |
+| , (Union type)              | The value must satisfy one of the subtypes   | `let :id, 1, 2 , 3`    |
 
 ## Contributing
 

--- a/lib/strong_csv/let.rb
+++ b/lib/strong_csv/let.rb
@@ -11,7 +11,10 @@ class StrongCSV
     end
 
     # @param name [String, Symbol, Integer]
-    def let(name, type)
+    # @param type [StrongCSV::Type::Base]
+    # @param types [Array<StrongCSV::Type::Base>]
+    def let(name, type, *types)
+      type = types.empty? ? type : Types::Union.new(type, *types)
       case name
       when Integer
         @types[name] = type

--- a/lib/strong_csv/types/base.rb
+++ b/lib/strong_csv/types/base.rb
@@ -7,10 +7,6 @@ class StrongCSV
       def cast(_value)
         raise NotImplementedError
       end
-
-      def |(other)
-        Union.new(self, other)
-      end
     end
   end
 end

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -18,10 +18,6 @@ class StrongCSV
         rescue ArgumentError, TypeError
           ValueResult.new(original_value: value, error_messages: ["`#{value.inspect}` can't be casted to Integer"])
         end
-
-        def |(other)
-          Union.new(self, other)
-        end
       end
     end
   end

--- a/lib/strong_csv/types/union.rb
+++ b/lib/strong_csv/types/union.rb
@@ -6,22 +6,21 @@ class StrongCSV
     class Union < Base
       using Types::Literal
 
-      # @param left [Base]
-      # @param right [Base]
-      def initialize(left, right)
+      # @param type [Array<Base>]
+      # @param types [Array<Base>]
+      def initialize(type, *types)
         super()
-        @left = left
-        @right = right
+        @types = [type, *types]
       end
 
       # @param value [Object] Value to be casted to Integer
       # @return [ValueResult]
       def cast(value)
-        left_result = @left.cast(value)
-        return left_result if left_result.success?
-
-        right_result = @right.cast(value)
-        right_result.success? ? right_result : left_result.tap { |l| l.error_messages.concat(right_result.error_messages).uniq! }
+        results = @types.map { |type| type.cast(value) }
+        results.find(&:success?) || results.reduce do |memo, result|
+          memo.error_messages.concat(result.error_messages).uniq!
+          memo
+        end
       end
     end
   end

--- a/test/types/boolean_test.rb
+++ b/test/types/boolean_test.rb
@@ -3,14 +3,14 @@
 require_relative "../test_helper"
 
 class TypesBooleanTest < Minitest::Test
-  def test_cast
+  def test_cast_for_boolean
     value_result = StrongCSV::Types::Boolean.new.cast("True")
     assert_instance_of StrongCSV::ValueResult, value_result
     assert value_result.success?
     assert value_result.value
   end
 
-  def test_cast_with_error
+  def test_cast_with_error_for_boolean
     value_result = StrongCSV::Types::Boolean.new.cast("1.3")
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?
@@ -18,7 +18,7 @@ class TypesBooleanTest < Minitest::Test
     assert_equal ['`"1.3"` can\'t be casted to Boolean'], value_result.error_messages
   end
 
-  def test_cast_with_nil_error
+  def test_cast_with_nil_error_for_boolean
     value_result = StrongCSV::Types::Boolean.new.cast(nil)
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?

--- a/test/types/integer_test.rb
+++ b/test/types/integer_test.rb
@@ -3,14 +3,14 @@
 require_relative "../test_helper"
 
 class TypesIntegerTest < Minitest::Test
-  def test_cast
+  def test_cast_for_integer
     value_result = StrongCSV::Types::Integer.new.cast("-1")
     assert_instance_of StrongCSV::ValueResult, value_result
     assert value_result.success?
     assert_equal(-1, value_result.value)
   end
 
-  def test_cast_with_error
+  def test_cast_with_error_for_integer
     value_result = StrongCSV::Types::Integer.new.cast("1.3")
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?
@@ -18,7 +18,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal ['`"1.3"` can\'t be casted to Integer'], value_result.error_messages
   end
 
-  def test_cast_with_nil_error
+  def test_cast_with_nil_error_for_integer
     value_result = StrongCSV::Types::Integer.new.cast(nil)
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?

--- a/test/types/literal_integer_test.rb
+++ b/test/types/literal_integer_test.rb
@@ -5,7 +5,7 @@ require_relative "../test_helper"
 class LiteralIntegerTest < Minitest::Test
   using StrongCSV::Types::Literal
 
-  def test_cast
+  def test_cast_literal_integer
     value_result = 123.cast("123")
     assert_instance_of StrongCSV::ValueResult, value_result
     assert value_result.success?
@@ -20,7 +20,7 @@ class LiteralIntegerTest < Minitest::Test
     assert_equal ["`8` is expected, but `13` was given"], value_result.error_messages
   end
 
-  def test_cast_with_error
+  def test_cast_with_error_for_literal_integer
     value_result = 8.cast("1.3")
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?
@@ -28,7 +28,7 @@ class LiteralIntegerTest < Minitest::Test
     assert_equal ['`"1.3"` can\'t be casted to Integer'], value_result.error_messages
   end
 
-  def test_cast_with_nil_error
+  def test_cast_with_nil_error_for_literal_integer
     value_result = 31.cast(nil)
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?

--- a/test/types/union_test.rb
+++ b/test/types/union_test.rb
@@ -3,16 +3,14 @@
 require_relative "../test_helper"
 
 class TypesIntegerTest < Minitest::Test
-  using StrongCSV::Types::Literal
-
-  def test_cast
+  def test_cast_for_union
     value_result = StrongCSV::Types::Union.new(12, 3).cast("3")
     assert_instance_of StrongCSV::ValueResult, value_result
     assert value_result.success?
     assert_equal 3, value_result.value
   end
 
-  def test_cast_with_error
+  def test_cast_with_error_for_union
     value_result = StrongCSV::Types::Union.new(10, 8).cast("1.3")
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?
@@ -20,7 +18,7 @@ class TypesIntegerTest < Minitest::Test
     assert_equal ['`"1.3"` can\'t be casted to Integer'], value_result.error_messages
   end
 
-  def test_cast_with_nil_error
+  def test_cast_with_nil_error_for_union
     value_result = StrongCSV::Types::Union.new(10, 11).cast(nil)
     assert_instance_of StrongCSV::ValueResult, value_result
     refute value_result.success?
@@ -38,7 +36,7 @@ class TypesIntegerTest < Minitest::Test
 
   def test_with_multiple_values
     strong_csv = StrongCSV.new do
-      let 0, integer | boolean
+      let 0, integer, boolean
     end
     result = strong_csv.parse(<<~CSV)
       123
@@ -53,7 +51,7 @@ class TypesIntegerTest < Minitest::Test
 
   def test_with_multiple_values_including_error
     strong_csv = StrongCSV.new do
-      let :id, integer | boolean
+      let :id, integer, boolean
     end
     result = strong_csv.parse(<<~CSV)
       id
@@ -83,7 +81,7 @@ class TypesIntegerTest < Minitest::Test
 
   def test_with_many_multiple_values
     strong_csv = StrongCSV.new do
-      let 0, 10 | 20 | 30 | 40 | 50
+      let 0, 10, 20, 30, 40, 50
     end
     result = strong_csv.parse(<<~CSV)
       15


### PR DESCRIPTION
I changed my mind that we should not require developers to use `using`
in their source code because it would not be intuitive for them.

`,` is just a method argument separator, so this gem does not seem to
affect users code base.

From this patch, this declaration means ":user_id must be 1, 2, or 3".

```ruby
let :user_id, 1, 2, 3
```