### PR TITLE
Support Range literal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Metrics/ClassLength:
 
 Metrics/MethodLength:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 30

--- a/README.md
+++ b/README.md
@@ -99,12 +99,13 @@ end
 
 ## Available types
 
-| Type                        | Description                                  | Example                |
-| --------------------------- | -------------------------------------------- | ---------------------- |
-| integer                     | The value must be casted to Integer          | `let :stock, integer`  |
-| boolean                     | The value must be casted to Boolean          | `let :active, boolean` |
-| 1, 2, ... (Integer literal) | The value must be casted to specific Integer | `let :id, 3`           |
-| , (Union type)              | The value must satisfy one of the subtypes   | `let :id, 1, 2, 3`     |
+| Type                                       | Description                                        | Example                |
+| ------------------------------------------ | -------------------------------------------------- | ---------------------- |
+| integer                                    | The value must be casted to Integer                | `let :stock, integer`  |
+| boolean                                    | The value must be casted to Boolean                | `let :active, boolean` |
+| 1, 2, ... (Integer literal)                | The value must be casted to specific Integer       | `let :id, 3`           |
+| 1..10, , 1.0..30, "a".."z" (Range literal) | The value must be casted to the beginning of Range | `let :id, 10..30`      |
+| , (Union type)                             | The value must satisfy one of the subtypes         | `let :id, 1, 2, 3`     |
 
 ## Contributing
 

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -19,6 +19,32 @@ class StrongCSV
           ValueResult.new(original_value: value, error_messages: ["`#{value.inspect}` can't be casted to Integer"])
         end
       end
+
+      refine Range do
+        # @param value [Object] Value to be casted to Integer
+        # @return [ValueResult]
+        def cast(value)
+          return ValueResult.new(original_value: value, error_messages: ["`nil` can't be casted to the beginning of `#{inspect}`"]) if value.nil?
+
+          casted = case self.begin
+                   when ::Float
+                     Float(value)
+                   when ::Integer
+                     Integer(value)
+                   when ::String
+                     value
+                   else
+                     raise TypeError, "#{self.begin.class} is not supported"
+                   end
+          if cover?(casted)
+            ValueResult.new(value: casted, original_value: value)
+          else
+            ValueResult.new(original_value: value, error_messages: ["`#{casted.inspect}` is not within `#{inspect}`"])
+          end
+        rescue ArgumentError
+          ValueResult.new(original_value: value, error_messages: ["`#{value.inspect}` can't be casted to the beginning of `#{inspect}`"])
+        end
+      end
     end
   end
 end

--- a/test/let_test.rb
+++ b/test/let_test.rb
@@ -41,6 +41,13 @@ class LetTest < Minitest::Test
     end
   end
 
+  def test_union_via_let
+    let = StrongCSV::Let.new
+    let.let(:id, 10..50, StrongCSV::Types::Boolean.new)
+    assert_instance_of StrongCSV::Types::Union, let.types[:id]
+    assert let.headers
+  end
+
   def test_integer
     assert_instance_of StrongCSV::Types::Integer, StrongCSV::Let.new.integer
   end

--- a/test/types/literal_range_test.rb
+++ b/test/types/literal_range_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class LiteralRangeTest < Minitest::Test
+  using StrongCSV::Types::Literal
+
+  def test_cast_literal_range_with_integer
+    value_result = (1...5).cast("4")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal 4, value_result.value
+  end
+
+  def test_cast_literal_range_with_float
+    value_result = (-1.0...5).cast("-0.999")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal(-0.999, value_result.value)
+  end
+
+  def test_cast_literal_range_with_string
+    value_result = ("a".."z").cast("z")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal "z", value_result.value
+  end
+
+  def test_cast_with_unexpected_value_for_literal_range
+    value_result = (1..34).cast("1.34")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "1.34", value_result.value
+    assert_equal ["`\"1.34\"` can't be casted to the beginning of `1..34`"], value_result.error_messages
+  end
+
+  def test_cast_with_error_for_literal_range
+    value_result = (1..34).cast("-1")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "-1", value_result.value
+    assert_equal ["`-1` is not within `1..34`"], value_result.error_messages
+  end
+
+  def test_cast_with_nil_error_for_literal_range
+    value_result = (0..9).cast(nil)
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_nil value_result.value
+    assert_equal ["`nil` can't be casted to the beginning of `0..9`"], value_result.error_messages
+  end
+
+  def test_initialize_without_headers
+    strong_csv = StrongCSV.new do
+      let 0, 1..6
+    end
+    strong_csv.parse("5") do |row|
+      assert_instance_of StrongCSV::Row, row
+      assert row.valid?
+      assert_equal 5, row[0]
+    end
+  end
+
+  def test_initialize_with_headers
+    strong_csv = StrongCSV.new do
+      let :id, "A".."Z"
+    end
+    data = <<~CSV
+      id
+      C
+    CSV
+    strong_csv.parse(data) do |row|
+      assert_instance_of StrongCSV::Row, row
+      assert row.valid?
+      assert_equal "C", row[:id]
+    end
+  end
+
+  def test_literal_range_with_invalid_value
+    strong_csv = StrongCSV.new do
+      let :id, 1..100
+    end
+    result = strong_csv.parse(<<~CSV)
+      id
+      abc
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["abc"], result.map { |row| row[:id] })
+    assert_equal([["`\"abc\"` can't be casted to the beginning of `1..100`"]], result.map { |row| row.errors[:id] })
+  end
+
+  def test_int_with_null
+    strong_csv = StrongCSV.new do
+      let :id, "a".."c"
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      b,
+      ,
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["b", nil], result.map { |row| row[:id] })
+    assert_equal([nil, ["`nil` can't be casted to the beginning of `\"a\"..\"c\"`"]], result.map { |row| row.errors[:id] })
+  end
+
+  def test_literal_range_with_blank_value
+    strong_csv = StrongCSV.new do
+      let :id, "a".."c"
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      b,
+      " "
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["b", " "], result.map { |row| row[:id] })
+    assert_equal([nil, ["`\" \"` is not within `\"a\"..\"c\"`"]], result.map { |row| row.errors[:id] })
+  end
+end


### PR DESCRIPTION
It would be useful to declare desired values with Range. I want to let
developers to write code like this:

```ruby
let :status, 1..10
let :abc, 1..10, 100..200
```