### PR TITLE
Support String literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,16 @@ end
 
 ## Available types
 
-| Type                                       | Description                                        | Example                             |
-| ------------------------------------------ | -------------------------------------------------- | ----------------------------------- |
-| integer                                    | The value must be casted to Integer                | `let :stock, integer`               |
-| float                                      | The value must be casted to Float                  | `let :rate, float`                  |
-| boolean                                    | The value must be casted to Boolean                | `let :active, boolean`              |
-| string OR string(within: 1..10)            | The value must be casted to String                 | `let :name, string(within: 1..255)` |
-| 1, 2, ... (Integer literal)                | The value must be casted to specific Integer       | `let :id, 3`                        |
-| 1..10, , 1.0..30, "a".."z" (Range literal) | The value must be casted to the beginning of Range | `let :id, 10..30`                   |
-| , (Union type)                             | The value must satisfy one of the subtypes         | `let :id, 1, 2, 3`                  |
+| Type                                           | Description                                                               | Example                             |
+| ---------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------- |
+| `integer`                                      | The value must be casted to Integer                                       | `let :stock, integer`               |
+| `float`                                        | The value must be casted to Float                                         | `let :rate, float`                  |
+| `boolean`                                      | The value must be casted to Boolean                                       | `let :active, boolean`              |
+| `string` OR `string(within: 1..10)`            | The value must be casted to String                                        | `let :name, string(within: 1..255)` |
+| `1`, `2`, ... (Integer literal)                | The value must be casted to the specific Integer literal                  | `let :id, 3`                        |
+| `1..10`, `1.0..30`, `"a".."z"` (Range literal) | The value must be casted to the beginning of Range and be covered with it | `let :id, 10..30`                   |
+| `"abc"`, `"bar"` (String literal)              | The value must be casted to the specific String literal                   | `let :drink, "coffee"`              |
+| , (Union type)                                 | The value must satisfy one of the subtypes                                | `let :id, 1, 2, 3`                  |
 
 ## Contributing
 

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -45,6 +45,18 @@ class StrongCSV
           ValueResult.new(original_value: value, error_messages: ["`#{value.inspect}` can't be casted to the beginning of `#{inspect}`"])
         end
       end
+
+      refine String do
+        # @param value [Object] Value to be casted to String
+        # @return [ValueResult]
+        def cast(value)
+          if self == value
+            ValueResult.new(value: self, original_value: value)
+          else
+            ValueResult.new(original_value: value, error_messages: ["`#{inspect}` is expected, but `#{value.inspect}` was given"])
+          end
+        end
+      end
     end
   end
 end

--- a/test/types/literal_string_test.rb
+++ b/test/types/literal_string_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class LiteralStringTest < Minitest::Test
+  using StrongCSV::Types::Literal
+
+  def test_cast_literal_string
+    value_result = "abc".cast("abc")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal "abc", value_result.value
+  end
+
+  def test_cast_with_unexpected_value
+    value_result = "x".cast("13")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "13", value_result.value
+    assert_equal ["`\"x\"` is expected, but `\"13\"` was given"], value_result.error_messages
+  end
+
+  def test_cast_with_nil_error_for_literal_string
+    value_result = "😇".cast(nil)
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_nil value_result.value
+    assert_equal ["`\"😇\"` is expected, but `nil` was given"], value_result.error_messages
+  end
+
+  def test_with_string_literal
+    strong_csv = StrongCSV.new do
+      let :id, "abc"
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      "abc"
+      ,
+      "xyz"
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["abc", nil, "xyz"], result.map { |row| row[:id] })
+    assert_equal([nil, ["`\"abc\"` is expected, but `nil` was given"], ["`\"abc\"` is expected, but `\"xyz\"` was given"]], result.map { |row| row.errors[:id] })
+  end
+
+  def test_with_string_literal_and_union
+    strong_csv = StrongCSV.new do
+      let :id, "abc", "xyz"
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      "abc"
+      "xyz"
+    CSV
+    assert result.all?(&:valid?)
+    assert_equal(%w[abc xyz], result.map { |row| row[:id] })
+  end
+end


### PR DESCRIPTION
I considered this declaration:

```ruby
let :state, "open", "in progress", "closed"
```

Sometimes, developers might want to make sure the field is set with
specific string literal. In this case, this patch would be useful.