### PR TITLE
Prefix :: to avoid ambiguous constant resolution

### DIFF
--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -20,7 +20,7 @@ class StrongCSV
         end
       end
 
-      refine Range do
+      refine ::Range do
         # @param value [Object] Value to be casted to Integer
         # @return [ValueResult]
         def cast(value)

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -46,7 +46,7 @@ class StrongCSV
         end
       end
 
-      refine String do
+      refine ::String do
         # @param value [Object] Value to be casted to String
         # @return [ValueResult]
         def cast(value)


### PR DESCRIPTION
`String` vs `::String`. Note we don't have our own `Range`, but I prefixed `Range` with `::` as well for consistency.