### PR TITLE
Support converter via the block of #let

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
+Style/HashLikeCase:
+  Enabled: false
+
 Layout/LineLength:
   Max: 240
 

--- a/lib/strong_csv/let.rb
+++ b/lib/strong_csv/let.rb
@@ -3,7 +3,11 @@
 class StrongCSV
   # Let is a class that is used to define types for columns.
   class Let
-    attr_reader :types, :headers
+    # @return [Hash{Symbol => [Types::Base, Proc]}]
+    attr_reader :types
+
+    # @return [Boolean]
+    attr_reader :headers
 
     def initialize
       @types = {}
@@ -13,13 +17,13 @@ class StrongCSV
     # @param name [String, Symbol, Integer]
     # @param type [StrongCSV::Type::Base]
     # @param types [Array<StrongCSV::Type::Base>]
-    def let(name, type, *types)
+    def let(name, type, *types, &block)
       type = types.empty? ? type : Types::Union.new(type, *types)
       case name
       when ::Integer
-        @types[name] = type
+        @types[name] = [type, block]
       when ::String, ::Symbol
-        @types[name.to_sym] = type
+        @types[name.to_sym] = [type, block]
       else
         raise TypeError, "Invalid type specified for `name`. `name` must be String, Symbol, or Integer: #{name.inspect}"
       end

--- a/lib/strong_csv/row.rb
+++ b/lib/strong_csv/row.rb
@@ -21,9 +21,9 @@ class StrongCSV
       @values = {}
       @errors = {}
       @lineno = lineno
-      types.each do |key, type|
+      types.each do |key, (type, block)|
         value_result = type.cast(row[key])
-        @values[key] = value_result.value
+        @values[key] = block && value_result.success? ? block.call(value_result.value) : value_result.value
         @errors[key] = value_result.error_messages unless value_result.success?
       end
     end

--- a/test/let_test.rb
+++ b/test/let_test.rb
@@ -7,7 +7,7 @@ class LetTest < Minitest::Test
     let = StrongCSV::Let.new
     let.let(:abc, 123)
     let.let(:xyz, 243)
-    assert_equal({ abc: 123, xyz: 243 }, let.types)
+    assert_equal({ abc: [123, nil], xyz: [243, nil] }, let.types)
     assert let.headers
   end
 
@@ -15,7 +15,7 @@ class LetTest < Minitest::Test
     let = StrongCSV::Let.new
     let.let("abc", 123)
     let.let("xyz", 243)
-    assert_equal({ abc: 123, xyz: 243 }, let.types)
+    assert_equal({ abc: [123, nil], xyz: [243, nil] }, let.types)
     assert let.headers
   end
 
@@ -23,7 +23,7 @@ class LetTest < Minitest::Test
     let = StrongCSV::Let.new
     let.let(0, 123)
     let.let(1, 89)
-    assert_equal({ 0 => 123, 1 => 89 }, let.types)
+    assert_equal({ 0 => [123, nil], 1 => [89, nil] }, let.types)
     refute let.headers
   end
 
@@ -41,10 +41,19 @@ class LetTest < Minitest::Test
     end
   end
 
+  def test_let_block
+    let = StrongCSV::Let.new
+    let.let(:id, "abc") { |v| v }
+    assert_equal "abc", let.types[:id][0]
+    assert_instance_of Proc, let.types[:id][1]
+    assert let.headers
+  end
+
   def test_union_via_let
     let = StrongCSV::Let.new
-    let.let(:id, 10..50, StrongCSV::Types::Boolean.new)
-    assert_instance_of StrongCSV::Types::Union, let.types[:id]
+    let.let(:id, 10..50, StrongCSV::Types::Boolean.new) { |v| v }
+    assert_instance_of StrongCSV::Types::Union, let.types[:id][0]
+    assert_instance_of Proc, let.types[:id][1]
     assert let.headers
   end
 

--- a/test/types/literal_string_test.rb
+++ b/test/types/literal_string_test.rb
@@ -55,4 +55,27 @@ class LiteralStringTest < Minitest::Test
     assert result.all?(&:valid?)
     assert_equal(%w[abc xyz], result.map { |row| row[:id] })
   end
+
+  def test_with_let_block
+    strong_csv = StrongCSV.new do
+      let :size, "S", "M", "L" do |size|
+        case size
+        when "S"
+          1
+        when "M"
+          2
+        when "L"
+          3
+        end
+      end
+    end
+    result = strong_csv.parse(<<~CSV)
+      size
+      S
+      M
+      L
+    CSV
+    assert result.all?(&:valid?)
+    assert_equal([1, 2, 3], result.map { |row| row[:size] })
+  end
 end


### PR DESCRIPTION
It would be useful to let developers pass block to `#let` like this:

```ruby
let :size, "S", "M", "L" do |size|
  case size
  when "S"
    1
  when "M"
    2
  when "L"
    3
  end
end
```

This patch adds support of block for `#let`.