### PR TITLE
Add Types::Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,18 +101,24 @@ end
 
 ## Available types
 
-| Type                     | Arguments | Description                                                               | Example                                                    |
-| ------------------------ | --------- | ------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `integer`                |           | The value must be casted to Integer                                       | `let :stock, integer`                                      |
-| `float`                  |           | The value must be casted to Float                                         | `let :rate, float`                                         |
-| `boolean`                |           | The value must be casted to Boolean                                       | `let :active, boolean`                                     |
-| `string`                 | `:within` | The value must be casted to String                                        | `let :name, string(within: 1..255)`                        |
-| `time`                   | `:format` | The value must be casted to Time                                          | `let :started_at, time(format: "%Y-%m-%dT%%H:%M:%S")`      |
-| `23` (Integer literal)   |           | The value must be casted to the specific Integer literal                  | `let :id, 3`                                               |
-| `15.12` (Float literal)  |           | The value must be casted to the specific Float literal                    | `let :id, 3.8`                                             |
-| `1..10` (Range literal)  |           | The value must be casted to the beginning of Range and be covered with it | `let :id, 10..30`, `let :id, 1.0..30`, `let :id, "a".."z"` |
-| `"abc"` (String literal) |           | The value must be casted to the specific String literal                   | `let :drink, "coffee"`                                     |
-| , (Union type)           |           | The value must satisfy one of the subtypes                                | `let :id, 1, 2, 3`                                         |
+| Type                     | Arguments | Description                                                                             | Example                                                    |
+| ------------------------ | --------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `integer`                |           | The value must be casted to Integer                                                     | `let :stock, integer`                                      |
+| `integer?`               |           | The value can be `nil`. If the value exists, it must satisfy `integer` constraint.      | `let :stock, integer?`                                     |
+| `float`                  |           | The value must be casted to Float                                                       | `let :rate, float`                                         |
+| `float?`                 |           | The value can be `nil`. If the value exists, it must satisfy `float` constraint.        | `let :rate, float?`                                        |
+| `boolean`                |           | The value must be casted to Boolean                                                     | `let :active, boolean`                                     |
+| `boolean?`               |           | The value can be `nil`. If the value exists, it must satisfy `boolean` constraint.      | `let :active, boolean?`                                    |
+| `string`                 | `:within` | The value must be casted to String                                                      | `let :name, string(within: 1..255)`                        |
+| `string?`                | `:within` | The value can be `nil`. If the value exists, it must satisfy `string` constraint.       | `let :name, string?(within: 1..255)`                       |
+| `time`                   | `:format` | The value must be casted to Time                                                        | `let :started_at, time(format: "%Y-%m-%dT%%H:%M:%S")`      |
+| `time?`                  | `:format` | The value can be `nil`. If the value exists, it must satisfy `time` constraint.         | `let :started_at, time?(format: "%Y-%m-%dT%%H:%M:%S")`     |
+| `optional`               | `type`    | The value can be `nil`. If the value exists, it must satisfy the given type constraint. | `let :foo, optional(123)                                   |
+| `23` (Integer literal)   |           | The value must be casted to the specific Integer literal                                | `let :id, 3`                                               |
+| `15.12` (Float literal)  |           | The value must be casted to the specific Float literal                                  | `let :id, 3.8`                                             |
+| `1..10` (Range literal)  |           | The value must be casted to the beginning of Range and be covered with it               | `let :id, 10..30`, `let :id, 1.0..30`, `let :id, "a".."z"` |
+| `"abc"` (String literal) |           | The value must be casted to the specific String literal                                 | `let :drink, "coffee"`                                     |
+| , (Union type)           |           | The value must satisfy one of the subtypes                                              | `let :id, 1, 2, 3`                                         |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ end
 | `string?`                | `:within` | The value can be `nil`. If the value exists, it must satisfy `string` constraint.       | `let :name, string?(within: 1..255)`                       |
 | `time`                   | `:format` | The value must be casted to Time                                                        | `let :started_at, time(format: "%Y-%m-%dT%%H:%M:%S")`      |
 | `time?`                  | `:format` | The value can be `nil`. If the value exists, it must satisfy `time` constraint.         | `let :started_at, time?(format: "%Y-%m-%dT%%H:%M:%S")`     |
-| `optional`               | `type`    | The value can be `nil`. If the value exists, it must satisfy the given type constraint. | `let :foo, optional(123)                                   |
+| `optional`               | `type`    | The value can be `nil`. If the value exists, it must satisfy the given type constraint. | `let :foo, optional(123)`                                  |
 | `23` (Integer literal)   |           | The value must be casted to the specific Integer literal                                | `let :id, 3`                                               |
 | `15.12` (Float literal)  |           | The value must be casted to the specific Float literal                                  | `let :id, 3.8`                                             |
 | `1..10` (Range literal)  |           | The value must be casted to the beginning of Range and be covered with it               | `let :id, 10..30`, `let :id, 1.0..30`, `let :id, "a".."z"` |

--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -31,7 +31,7 @@ class StrongCSV
   # @param csv [String, IO]
   # @param options [Hash] CSV options for parsing.
   def parse(csv, **options)
-    # NOTE: Some options are overridden here to ensure so that StrongCSV can handle parsed values correctly.
+    # NOTE: Some options are overridden here to ensure that StrongCSV can handle parsed values correctly.
     options = options.merge(headers: @let.headers, nil_value: nil, header_converters: :symbol)
     csv = CSV.new(csv, **options)
     if block_given?

--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -12,6 +12,7 @@ require_relative "strong_csv/types/boolean"
 require_relative "strong_csv/types/float"
 require_relative "strong_csv/types/integer"
 require_relative "strong_csv/types/literal"
+require_relative "strong_csv/types/optional"
 require_relative "strong_csv/types/string"
 require_relative "strong_csv/types/time"
 require_relative "strong_csv/types/union"
@@ -30,7 +31,8 @@ class StrongCSV
   # @param csv [String, IO]
   # @param options [Hash] CSV options for parsing.
   def parse(csv, **options)
-    options = options.merge(headers: @let.headers, header_converters: :symbol)
+    # NOTE: Some options are overridden here to ensure so that StrongCSV can handle parsed values correctly.
+    options = options.merge(headers: @let.headers, nil_value: nil, header_converters: :symbol)
     csv = CSV.new(csv, **options)
     if block_given?
       csv.each do |row|

--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -32,7 +32,8 @@ class StrongCSV
   # @param options [Hash] CSV options for parsing.
   def parse(csv, **options)
     # NOTE: Some options are overridden here to ensure that StrongCSV can handle parsed values correctly.
-    options = options.merge(headers: @let.headers, nil_value: nil, header_converters: :symbol)
+    options.delete(:nil_value)
+    options = options.merge(headers: @let.headers, header_converters: :symbol)
     csv = CSV.new(csv, **options)
     if block_given?
       csv.each do |row|

--- a/lib/strong_csv/let.rb
+++ b/lib/strong_csv/let.rb
@@ -34,12 +34,24 @@ class StrongCSV
       Types::Integer.new
     end
 
+    def integer?
+      optional(integer)
+    end
+
     def boolean
       Types::Boolean.new
     end
 
+    def boolean?
+      optional(boolean)
+    end
+
     def float
       Types::Float.new
+    end
+
+    def float?
+      optional(float)
     end
 
     # @param options [Hash] See `Types::String#initialize` for more details.
@@ -47,9 +59,22 @@ class StrongCSV
       Types::String.new(**options)
     end
 
+    def string?(**options)
+      optional(string(**options))
+    end
+
     # @param options [Hash] See `Types::Time#initialize` for more details.
     def time(**options)
       Types::Time.new(**options)
+    end
+
+    def time?(**options)
+      optional(time(**options))
+    end
+
+    # @param args [Array] See `Types::Optional#initialize` for more details.
+    def optional(*args)
+      Types::Optional.new(*args)
     end
 
     private

--- a/lib/strong_csv/types/optional.rb
+++ b/lib/strong_csv/types/optional.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class StrongCSV
+  module Types
+    # Optional type
+    class Optional < Base
+      using Types::Literal
+
+      # @param type [Base]
+      def initialize(type)
+        super()
+        @type = type
+      end
+
+      # @param value [Object]
+      # @return [ValueResult]
+      def cast(value)
+        value.nil? ? ValueResult.new(value: nil, original_value: value) : @type.cast(value)
+      end
+    end
+  end
+end

--- a/test/let_test.rb
+++ b/test/let_test.rb
@@ -61,12 +61,27 @@ class LetTest < Minitest::Test
     assert_instance_of StrongCSV::Types::Integer, StrongCSV::Let.new.integer
   end
 
+  def test_integer?
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.integer?
+    assert_instance_of StrongCSV::Types::Integer, StrongCSV::Let.new.integer?.instance_variable_get(:@type)
+  end
+
   def test_boolean
     assert_instance_of StrongCSV::Types::Boolean, StrongCSV::Let.new.boolean
   end
 
+  def test_boolean?
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.boolean?
+    assert_instance_of StrongCSV::Types::Boolean, StrongCSV::Let.new.boolean?.instance_variable_get(:@type)
+  end
+
   def test_float
     assert_instance_of StrongCSV::Types::Float, StrongCSV::Let.new.float
+  end
+
+  def test_float?
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.float?
+    assert_instance_of StrongCSV::Types::Float, StrongCSV::Let.new.float?.instance_variable_get(:@type)
   end
 
   def test_string
@@ -74,8 +89,24 @@ class LetTest < Minitest::Test
     assert_instance_of StrongCSV::Types::String, StrongCSV::Let.new.string(within: 1..10)
   end
 
+  def test_string?
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.string?
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.string?(within: 1..10)
+    assert_instance_of StrongCSV::Types::String, StrongCSV::Let.new.string?.instance_variable_get(:@type)
+  end
+
   def test_time
     assert_instance_of StrongCSV::Types::Time, StrongCSV::Let.new.time
     assert_instance_of StrongCSV::Types::Time, StrongCSV::Let.new.time(format: "%H:%M")
+  end
+
+  def test_time?
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.time?
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.time?(format: "%H:%M")
+    assert_instance_of StrongCSV::Types::Time, StrongCSV::Let.new.time?.instance_variable_get(:@type)
+  end
+
+  def test_optional
+    assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.optional(123)
   end
 end

--- a/test/types/optional_test.rb
+++ b/test/types/optional_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class TypesOptionalTest < Minitest::Test
+  def test_cast
+    value_result = StrongCSV::Types::Optional.new(StrongCSV::Types::Integer.new).cast("-1")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal(-1, value_result.value)
+  end
+
+  def test_cast_unexpected_value
+    value_result = StrongCSV::Types::Optional.new(StrongCSV::Types::Integer.new).cast("1.3")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "1.3", value_result.value
+    assert_equal ['`"1.3"` can\'t be casted to Integer'], value_result.error_messages
+  end
+
+  def test_cast_nil
+    value_result = StrongCSV::Types::Optional.new(StrongCSV::Types::Integer.new).cast(nil)
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_nil value_result.value
+  end
+
+  def test_without_headers
+    strong_csv = StrongCSV.new do
+      let 0, optional(integer)
+    end
+    strong_csv.parse("40") do |row|
+      assert_instance_of StrongCSV::Row, row
+      assert row.valid?
+      assert_equal 40, row[0]
+    end
+  end
+
+  def test_with_headers
+    strong_csv = StrongCSV.new do
+      let :id, integer?
+    end
+    data = <<~CSV
+      id
+      4,5,6
+    CSV
+    strong_csv.parse(data) do |row|
+      assert_instance_of StrongCSV::Row, row
+      assert row.valid?
+      assert_equal 4, row[:id]
+    end
+  end
+
+  def test_strong_csv_for_with_optional_integer
+    strong_csv = StrongCSV.new do
+      let 0, optional(integer)
+    end
+    result = strong_csv.parse("\n\n\n123\n")
+    assert result.all?(&:valid?)
+    assert_equal([nil, nil, nil, 123], result.map { |row| row[0] })
+  end
+
+  def test_strong_csv_for_with_optional_string
+    strong_csv = StrongCSV.new do
+      let 0, string?(within: 1..10)
+    end
+    result = strong_csv.parse("\n\nabc\n\n")
+    assert result.all?(&:valid?)
+    assert_equal([nil, nil, "abc", nil], result.map { |row| row[0] })
+  end
+
+  def test_strong_csv_for_with_optional_float
+    strong_csv = StrongCSV.new do
+      let 0, float?
+    end
+    result = strong_csv.parse("\n\n1.2\n\n")
+    assert result.all?(&:valid?)
+    assert_equal([nil, nil, 1.2, nil], result.map { |row| row[0] })
+  end
+
+  def test_strong_csv_for_with_optional_boolean
+    strong_csv = StrongCSV.new do
+      let 0, boolean?
+    end
+    result = strong_csv.parse("True\n\nfalse\n\n")
+    assert result.all?(&:valid?)
+    assert_equal([true, nil, false, nil], result.map { |row| row[0] })
+  end
+
+  def test_strong_csv_for_with_optional_time
+    strong_csv = StrongCSV.new do
+      let 0, time?
+    end
+    result = strong_csv.parse("2022-06-09\n\n2015-05-03\n\n")
+    assert result.all?(&:valid?)
+    assert_equal([Time.new(2022, 6, 9), nil, Time.new(2015, 5, 3), nil], result.map { |row| row[0] })
+  end
+
+  def test_strong_csv_for_with_optional_literal
+    strong_csv = StrongCSV.new do
+      let 0, optional("yy")
+    end
+    result = strong_csv.parse("\n\nyy\n\n")
+    assert result.all?(&:valid?)
+    assert_equal([nil, nil, "yy", nil], result.map { |row| row[0] })
+  end
+
+  def test_strong_csv_for_with_optional_union_literal
+    strong_csv = StrongCSV.new do
+      let 0, optional("yy"), optional("xx")
+    end
+    result = strong_csv.parse("\nxx\nyy\n\n")
+    assert result.all?(&:valid?)
+    assert_equal([nil, "xx", "yy", nil], result.map { |row| row[0] })
+  end
+end


### PR DESCRIPTION
Optional values might be necessary for most applications that handle CSV
files. This patch introduces `Types::Optional` and developers can
declare optional CSV columns like this:

```ruby
let :description, string?(within: 1..1000)
```