### PR TITLE
Add #slice to Row

### DIFF
--- a/lib/strong_csv/row.rb
+++ b/lib/strong_csv/row.rb
@@ -6,7 +6,7 @@ class StrongCSV
     extend Forwardable
     using Types::Literal
 
-    def_delegators :@values, :[], :fetch
+    def_delegators :@values, :[], :fetch, :slice
 
     # @return [Hash]
     attr_reader :errors

--- a/test/row_test.rb
+++ b/test/row_test.rb
@@ -20,6 +20,13 @@ class RowTest < Minitest::Test
     assert_equal 2, row.lineno
   end
 
+  def test_row_forwardable
+    row = StrongCSV::Row.new(row: %w[☕️ 12.0], types: { 0 => [StrongCSV::Types::String.new, nil], 1 => [StrongCSV::Types::Float.new, nil] }, lineno: 3)
+    assert_equal({ 0 => "☕️", 1 => 12.0 }, row.slice(0, 1))
+    assert_equal "☕️", row[0]
+    assert_equal 12.0, row.fetch(1)
+  end
+
   def test_row_with_invalid_data
     csv_row = CSV::Row.new(%i[abc], %w[abc!])
     row = StrongCSV::Row.new(row: csv_row, types: { abc: [StrongCSV::Types::Integer.new, nil], x: [StrongCSV::Types::Integer.new, nil] }, lineno: 2)


### PR DESCRIPTION
`Row#slice` might be useful when you want to extract specific multiple
fields at the same time.