### PR TITLE
Support Regexp literal as a type

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ strong_csv = StrongCSV.new do
     end
   end
 
-  # TODO: The followings are not implemented so far.
-
   # Regular expressions
   let :url, %r{\Ahttps://}
+
+  # TODO: The followings are not implemented so far.
 
   # Custom validation
   #
@@ -405,6 +405,9 @@ ja:
       range:
         cant_be_casted: "`%{value}`は`%{expected}`の始端に変換できません"
         out_of_range: "`%{value}`は`%{range}`の範囲外です"
+      regexp:
+        cant_be_casted: "`%{value}`はStringに変換できません"
+        unexpected: "`%{value}`は`%{expected}`とマッチしませんでした"
     string:
       cant_be_casted: "`%{value}`はStringに変換できません"
       out_of_range: "`%{value}`の文字数は`%{range}`の範囲外です"

--- a/lib/strong_csv/i18n.rb
+++ b/lib/strong_csv/i18n.rb
@@ -28,6 +28,10 @@ I18n.backend.store_translations(
           cant_be_casted: "`%{value}` can't be casted to the beginning of `%{expected}`",
           out_of_range: "`%{value}` is not within `%{range}`",
         },
+        regexp: {
+          cant_be_casted: "`%{value}` can't be casted to String",
+          unexpected: "`%{value}` did not match `%{expected}`",
+        },
       },
       string: {
         cant_be_casted: "`%{value}` can't be casted to String",

--- a/lib/strong_csv/types/literal.rb
+++ b/lib/strong_csv/types/literal.rb
@@ -72,6 +72,20 @@ class StrongCSV
           end
         end
       end
+
+      refine ::Regexp do
+        # @param value [Object] Value to be casted to String
+        # @return [ValueResult]
+        def cast(value)
+          return ValueResult.new(original_value: value, error_messages: [I18n.t("strong_csv.literal.regexp.cant_be_casted", value: value.inspect, default: :"_strong_csv.literal.regexp.cant_be_casted")]) if value.nil?
+
+          if self =~ value
+            ValueResult.new(value: value, original_value: value)
+          else
+            ValueResult.new(original_value: value, error_messages: [I18n.t("strong_csv.literal.regexp.unexpected", value: value.inspect, expected: inspect, default: :"_strong_csv.literal.regexp.unexpected")])
+          end
+        end
+      end
     end
   end
 end

--- a/test/types/literal_regexp_test.rb
+++ b/test/types/literal_regexp_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class LiteralRegexpTest < Minitest::Test
+  using StrongCSV::Types::Literal
+
+  def test_cast
+    value_result = /\Aabc/.cast("abc!!!")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    assert value_result.success?
+    assert_equal "abc!!!", value_result.value
+  end
+
+  def test_cast_unexpected_value
+    value_result = /\A\d+\z/.cast("1df3")
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_equal "1df3", value_result.value
+    assert_equal ["`\"1df3\"` did not match `/\\A\\d+\\z/`"], value_result.error_messages
+  end
+
+  def test_cast_nil
+    value_result = /abc/.cast(nil)
+    assert_instance_of StrongCSV::ValueResult, value_result
+    refute value_result.success?
+    assert_nil value_result.value
+    assert_equal ["`nil` can't be casted to String"], value_result.error_messages
+  end
+
+  def test_with_regexp_literal
+    strong_csv = StrongCSV.new do
+      let :id, /\A\w+\z/
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      "abc_123"
+      ,
+      "xyz_456!"
+    CSV
+    refute result.all?(&:valid?)
+    assert_equal(["abc_123", nil, "xyz_456!"], result.map { |row| row[:id] })
+    assert_equal([nil, ["`nil` can't be casted to String"], ["`\"xyz_456!\"` did not match `/\\A\\w+\\z/`"]], result.map { |row| row.errors[:id] })
+  end
+
+  def test_with_regexp_literal_and_union
+    strong_csv = StrongCSV.new do
+      let :id, /\A\d+\z/, /\A[a-z]+\z/
+    end
+    result = strong_csv.parse(<<~CSV)
+      id,
+      "abcz"
+      "123"
+    CSV
+    assert result.all?(&:valid?)
+    assert_equal(%w[abcz 123], result.map { |row| row[:id] })
+  end
+end


### PR DESCRIPTION
Regular expression is powerful when we want to define some custom
validations, so supporting Regexp might be useful for users.