### PR TITLE
Add Let#pick to declare value picker and support constraint in Integer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,6 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 30
+
+Naming/MethodParameterName:
+  Enabled: false

--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -37,6 +37,12 @@ class StrongCSV
     options.delete(:nil_value)
     options = options.merge(headers: @let.headers, header_converters: :symbol)
     csv = CSV.new(csv, **options)
+
+    @let.pickers.each_value do |picker|
+      picker.call(csv)
+      csv.rewind
+    end
+
     if block_given?
       csv.each do |row|
         yield Row.new(row: row, types: @let.types, lineno: csv.lineno)

--- a/lib/strong_csv/i18n.rb
+++ b/lib/strong_csv/i18n.rb
@@ -11,6 +11,7 @@ I18n.backend.store_translations(
       },
       integer: {
         cant_be_casted: "`%{value}` can't be casted to Integer",
+        constraint_error: "`%{value}` does not satisfy the specified constraint",
       },
       literal: {
         integer: {

--- a/lib/strong_csv/types/integer.rb
+++ b/lib/strong_csv/types/integer.rb
@@ -4,11 +4,25 @@ class StrongCSV
   module Types
     # Integer type
     class Integer < Base
+      DEFAULT_CONSTRAINT = ->(_) { true }
+      private_constant :DEFAULT_CONSTRAINT
+
+      # @param constraint [Proc]
+      def initialize(constraint: DEFAULT_CONSTRAINT)
+        super()
+        @constraint = constraint
+      end
+
       # @todo Use :exception for Integer after we drop the support of Ruby 2.5
       # @param value [Object] Value to be casted to Integer
       # @return [ValueResult]
       def cast(value)
-        ValueResult.new(value: Integer(value), original_value: value)
+        int = Integer(value)
+        if @constraint.call(int)
+          ValueResult.new(value: int, original_value: value)
+        else
+          ValueResult.new(original_value: value, error_messages: [I18n.t("strong_csv.integer.constraint_error", value: value.inspect, default: :"_strong_csv.integer.constraint_error")])
+        end
       rescue ArgumentError, TypeError
         ValueResult.new(original_value: value, error_messages: [I18n.t("strong_csv.integer.cant_be_casted", value: value.inspect, default: :"_strong_csv.integer.cant_be_casted")])
       end

--- a/test/let_test.rb
+++ b/test/let_test.rb
@@ -59,11 +59,13 @@ class LetTest < Minitest::Test
 
   def test_integer
     assert_instance_of StrongCSV::Types::Integer, StrongCSV::Let.new.integer
+    assert_instance_of StrongCSV::Types::Integer, StrongCSV::Let.new.integer(constraint: ->(_v) { true })
   end
 
   def test_integer?
     assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.integer?
     assert_instance_of StrongCSV::Types::Integer, StrongCSV::Let.new.integer?.instance_variable_get(:@type)
+    assert_instance_of StrongCSV::Types::Integer, StrongCSV::Let.new.integer?(constraint: ->(_v) { true }).instance_variable_get(:@type)
   end
 
   def test_boolean


### PR DESCRIPTION
Users sometimes might want to pick data from a database with the
specified IDs. For example, when a user want to receive `:user_id`
and want to make sure the value really exists in the database.

In this case, the new rule `constraint` would be useful because it can
ensure the casted value satisfies the specified constraint. However,
accessing to the database per CSV row causes N+1. In order to avoid this
problem, `Let#pick` is also introduced in this patch. `Let#pick` is
intended for storing data in advance of evaluating each CSV row and lets
users put limitation to Integer validation with the stored data.

For now, constraint is only supported in `Types::Integer`, but I want to
give this feature to other types.