### PR TITLE
Add :constraint to Types::Float

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ result[2].errors.slice(:stock, :user_id) # => {:stock=>["`\"non-integer\"` can't
 ### `float` and `float?`
 
 The value must be casted to Float. `float?` allows the value to be `nil`, so you can declare optional float type for
-columns.
+columns. It also lets you allow values that satisfy the specified limitation through `:constraint`.
 
 _Example_
 
@@ -399,6 +399,7 @@ ja:
       cant_be_casted: "`%{value}`はBooleanに変換できません"
     float:
       cant_be_casted: "`%{value}`はFloatに変換できません"
+      constraint_error: "`%{value}`は指定された成約を満たしていません",
     integer:
       cant_be_casted: "`%{value}`はIntegerに変換できません"
       constraint_error: "`%{value}`は指定された成約を満たしていません",

--- a/lib/strong_csv/i18n.rb
+++ b/lib/strong_csv/i18n.rb
@@ -8,6 +8,7 @@ I18n.backend.store_translations(
       },
       float: {
         cant_be_casted: "`%{value}` can't be casted to Float",
+        constraint_error: "`%{value}` does not satisfy the specified constraint",
       },
       integer: {
         cant_be_casted: "`%{value}` can't be casted to Integer",

--- a/lib/strong_csv/let.rb
+++ b/lib/strong_csv/let.rb
@@ -74,12 +74,14 @@ class StrongCSV
       optional(boolean)
     end
 
-    def float
-      Types::Float.new
+    # @param options [Hash] See `Types::Float#initialize` for more details.
+    def float(**options)
+      Types::Float.new(**options)
     end
 
-    def float?
-      optional(float)
+    # @param options [Hash] See `Types::Float#initialize` for more details.
+    def float?(**options)
+      optional(float(**options))
     end
 
     # @param options [Hash] See `Types::String#initialize` for more details.

--- a/lib/strong_csv/types/float.rb
+++ b/lib/strong_csv/types/float.rb
@@ -4,11 +4,25 @@ class StrongCSV
   module Types
     # Float type
     class Float < Base
+      DEFAULT_CONSTRAINT = ->(_) { true }
+      private_constant :DEFAULT_CONSTRAINT
+
+      # @param constraint [Proc]
+      def initialize(constraint: DEFAULT_CONSTRAINT)
+        super()
+        @constraint = constraint
+      end
+
       # @todo Use :exception for Float after we drop the support of Ruby 2.5
       # @param value [Object] Value to be casted to Float
       # @return [ValueResult]
       def cast(value)
-        ValueResult.new(value: Float(value), original_value: value)
+        float = Float(value)
+        if @constraint.call(float)
+          ValueResult.new(value: float, original_value: value)
+        else
+          ValueResult.new(original_value: value, error_messages: [I18n.t("strong_csv.float.constraint_error", value: value.inspect, default: :"_strong_csv.float.constraint_error")])
+        end
       rescue ArgumentError, TypeError
         ValueResult.new(original_value: value, error_messages: [I18n.t("strong_csv.float.cant_be_casted", value: value.inspect, default: :"_strong_csv.float.cant_be_casted")])
       end

--- a/test/let_test.rb
+++ b/test/let_test.rb
@@ -79,11 +79,13 @@ class LetTest < Minitest::Test
 
   def test_float
     assert_instance_of StrongCSV::Types::Float, StrongCSV::Let.new.float
+    assert_instance_of StrongCSV::Types::Float, StrongCSV::Let.new.float(constraint: ->(_v) { true })
   end
 
   def test_float?
     assert_instance_of StrongCSV::Types::Optional, StrongCSV::Let.new.float?
     assert_instance_of StrongCSV::Types::Float, StrongCSV::Let.new.float?.instance_variable_get(:@type)
+    assert_instance_of StrongCSV::Types::Float, StrongCSV::Let.new.float?(constraint: ->(_v) { true }).instance_variable_get(:@type)
   end
 
   def test_string


### PR DESCRIPTION
Like https://github.com/yykamei/strong_csv/pull/45,
this patch introduces `:constraint` in `Types::Float`.

You can narrow the value with the specified `Proc`.