### PR TITLE
Update `ValueResult` API docs

### DIFF
--- a/lib/strong_csv/value_result.rb
+++ b/lib/strong_csv/value_result.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StrongCSV
-  # ValueResult represents a CSV field is valid or not and contains its casted value if it's valid.
+  # ValueResult represents whether a CSV field is valid or not, and contains its casted value if it's valid.
   class ValueResult
     DEFAULT_VALUE = Object.new
     private_constant :DEFAULT_VALUE
@@ -15,11 +15,13 @@ class StrongCSV
       @error_messages = error_messages
     end
 
-    # @return [::Float, ::Integer, ::Object, ::String, ::Range, boolean, ::Time, nil] The casted value if it's valid. Otherwise, returns the original value.
+    # @return [::Float, ::Integer, ::Object, ::String, ::Range, Boolean, ::Time, nil] The casted value if it's valid. Otherwise, returns the original value.
     def value
       success? ? @value : @original_value
     end
 
+    # It returns true if the value is successfully casted.
+    #
     # @return [Boolean]
     def success?
       @error_messages.nil?

--- a/sig/strong_csv.rbs
+++ b/sig/strong_csv.rbs
@@ -2,7 +2,7 @@
 
 type literals = ::Integer | ::Float | ::Range[untyped] | ::String | ::Regexp
 type declarable = StrongCSV::Types::Base | literals
-type casted = bool | ::Float | ::Integer | ::Range[untyped] | ::String | ::Regexp
+type casted = bool | ::Float | ::Integer | ::Range[untyped] | ::String | ::Regexp | ::Time
 type column = ::Integer | ::Symbol
 
 # Classes


### PR DESCRIPTION
The casted value might be `::Time` as well.
In addition to adding `::Time` to `casted`, I changed the API docs for
`ValueResult` methods.