### PR TITLE
Set `bundler` for Ruby 2.5 on ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          bundler: ${{ matrix.ruby == '2.5' && '2.2.28' || 'latest' }}
 
       - run: bundle exec rbs collection install
 


### PR DESCRIPTION
I want to continue supporting Ruby 2.5, but [the CI](https://github.com/yykamei/strong_csv/actions/runs/3771786817/jobs/6412361739) fails because of incompatibility between Ruby 2.5 and bundler. I want to try [`bundler` option](https://github.com/ruby/setup-ruby/blob/4b2d1d631efa087f8896c15a0c6023dc2f483198/action.yml#L17) for ruby/setup-ruby by specifying an explicit version only with Ruby 2.5.