### PR TITLE
Run Ruby 3.2 on ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ruby 3.2 has been released 🎉

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/