### PR TITLE
Support :error_message on #let

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ strong_csv = StrongCSV.new do
   let :description, string?(within: 1..1000)
   let :active, boolean
   let :started_at, time?(format: "%Y-%m-%dT%H:%M:%S")
+  let :price, integer, error_message: "This should be Integer"
 
   # Literal declaration
   let :status, 0..6
@@ -91,8 +92,8 @@ strong_csv = StrongCSV.new do
 end
 
 data = <<~CSV
-  stock,tax_rate,name,active,status,priority,size,url
-  12,0.8,special item,True,4,20,M,https://example.com
+  stock,tax_rate,name,active,status,priority,size,url,price
+  12,0.8,special item,True,4,20,M,https://example.com,PRICE
 CSV
 
 strong_csv.parse(data, field_size_limit: 2048) do |row|
@@ -101,7 +102,7 @@ strong_csv.parse(data, field_size_limit: 2048) do |row|
     row[:active] # => true
     # do something with row
   else
-    row.errors # => { user_id: ["`nil` can't be casted to Integer"] }
+    row.errors # => {:price=>["This should be Integer"], :user_id=>["`nil` can't be casted to Integer"]}
     # do something with row.errors
   end
 end

--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -16,6 +16,7 @@ require_relative "strong_csv/types/optional"
 require_relative "strong_csv/types/string"
 require_relative "strong_csv/types/time"
 require_relative "strong_csv/types/union"
+require_relative "strong_csv/type_wrapper"
 require_relative "strong_csv/let"
 require_relative "strong_csv/row"
 

--- a/lib/strong_csv/row.rb
+++ b/lib/strong_csv/row.rb
@@ -4,7 +4,6 @@ class StrongCSV
   # Row is a representation of a row in a CSV file, which has casted values with specified types.
   class Row
     extend Forwardable
-    using Types::Literal
 
     def_delegators :@values, :[], :fetch, :slice
 
@@ -21,10 +20,10 @@ class StrongCSV
       @values = {}
       @errors = {}
       @lineno = lineno
-      types.each do |key, (type, block)|
-        value_result = type.cast(row[key])
-        @values[key] = block && value_result.success? ? block.call(value_result.value) : value_result.value
-        @errors[key] = value_result.error_messages unless value_result.success?
+      types.each do |wrapper|
+        cell = row[wrapper.name]
+        @values[wrapper.name], error = wrapper.cast(cell)
+        @errors[wrapper.name] = error if error
       end
     end
 

--- a/lib/strong_csv/type_wrapper.rb
+++ b/lib/strong_csv/type_wrapper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class StrongCSV # rubocop:disable Style/Documentation
+  using Types::Literal
+
+  # TypeWrapper holds the `type` along with `name` and `block`. It might be useful to store metadata for the type,
+  # such as `error_message`.
+  #
+  # @!attribute name
+  #   @return [Symbol, Integer] The name for the type. This is the CSV header name. If the CSV does not have its header, Integer should be set.
+  # @!attribute type
+  #   @return [StrongCSV::Type::Base]
+  # @!attribute error_message
+  #   @return [String, nil] The error message returned if #cast fails. If omitted, the default error message will be used.
+  # @!attribute block
+  #   @return [Proc]
+  TypeWrapper = Struct.new(:name, :type, :error_message, :block, keyword_init: true) do
+    def cast(value)
+      value_result = type.cast(value)
+      casted = block && value_result.success? ? block.call(value_result.value) : value_result.value
+      error = if value_result.success?
+                nil
+              else
+                error_message ? [error_message] : value_result.error_messages
+              end
+
+      [casted, error]
+    end
+  end
+end

--- a/sig/strong_csv.rbs
+++ b/sig/strong_csv.rbs
@@ -107,14 +107,13 @@ class StrongCSV
   class Let
     @picked: Hash[untyped, untyped]
 
-    attr_reader types: Hash[column, [declarable, ^(casted) -> untyped | nil]]
+    attr_reader types: Array[TypeWrapper]
     attr_reader headers: bool
     attr_reader pickers: Hash[untyped, Proc]
 
     def initialize: -> void
 
-    def let: (::String | column, declarable, *declarable) -> void
-      | (::String | column, declarable, *declarable) { (casted) -> untyped } -> void
+    def let: (::String | column, declarable, *declarable, ?error_message: ::String?) ?{ (casted) -> untyped } -> void
 
     def pick: (column, as: ::Symbol) { (Array[::String]) -> untyped } -> void
 
@@ -153,9 +152,18 @@ class StrongCSV
     attr_reader errors: Hash[column, Array[::String]]
     attr_reader lineno: ::Integer
 
-    def initialize: (row: Array[::String] | CSV::Row, types: Hash[column, [declarable, (^(casted | ::Object | nil) -> untyped | nil)]], lineno: ::Integer) -> void
+    def initialize: (row: Array[::String] | CSV::Row, types: Array[TypeWrapper], lineno: ::Integer) -> void
 
     def valid?: -> bool
+  end
+
+  class TypeWrapper
+    attr_accessor name: (::Symbol | ::Integer)
+    attr_accessor type: declarable
+    attr_accessor error_message: (::String | nil)
+    attr_accessor block: (^(casted | ::Object | nil) -> untyped | nil)
+
+    def cast: (::String | nil) -> [(casted | ::Object | nil), (::String | nil)]
   end
 
   class Error < StandardError

--- a/test/let_test.rb
+++ b/test/let_test.rb
@@ -8,7 +8,7 @@ class LetTest < Minitest::Test
     let.let(:abc, 123)
     let.let(:xyz, 243)
 
-    assert_equal({ abc: [123, nil], xyz: [243, nil] }, let.types)
+    assert_equal [StrongCSV::TypeWrapper.new(name: :abc, type: 123), StrongCSV::TypeWrapper.new(name: :xyz, type: 243)], let.types
     assert let.headers
   end
 
@@ -17,7 +17,7 @@ class LetTest < Minitest::Test
     let.let("abc", 123)
     let.let("xyz", 243)
 
-    assert_equal({ abc: [123, nil], xyz: [243, nil] }, let.types)
+    assert_equal [StrongCSV::TypeWrapper.new(name: :abc, type: 123), StrongCSV::TypeWrapper.new(name: :xyz, type: 243)], let.types
     assert let.headers
   end
 
@@ -26,7 +26,7 @@ class LetTest < Minitest::Test
     let.let(0, 123)
     let.let(1, 89)
 
-    assert_equal({ 0 => [123, nil], 1 => [89, nil] }, let.types)
+    assert_equal [StrongCSV::TypeWrapper.new(name: 0, type: 123), StrongCSV::TypeWrapper.new(name: 1, type: 89)], let.types
     refute let.headers
   end
 
@@ -49,8 +49,8 @@ class LetTest < Minitest::Test
     let = StrongCSV::Let.new
     let.let(:id, "abc") { |v| v }
 
-    assert_equal "abc", let.types[:id][0]
-    assert_instance_of Proc, let.types[:id][1]
+    assert_equal "abc", let.types[0].type
+    assert_instance_of Proc, let.types[0].block
     assert let.headers
   end
 
@@ -58,9 +58,16 @@ class LetTest < Minitest::Test
     let = StrongCSV::Let.new
     let.let(:id, 10..50, StrongCSV::Types::Boolean.new) { |v| v }
 
-    assert_instance_of StrongCSV::Types::Union, let.types[:id][0]
-    assert_instance_of Proc, let.types[:id][1]
+    assert_instance_of StrongCSV::Types::Union, let.types[0].type
+    assert_instance_of Proc, let.types[0].block
     assert let.headers
+  end
+
+  def test_error_message_via_let
+    let = StrongCSV::Let.new
+    let.let(0, "book", error_message: "My custom error message")
+
+    assert_equal "My custom error message", let.types[0].error_message
   end
 
   def test_integer


### PR DESCRIPTION
Users of strong_csv might want to show their custom error message when the provided CSV is invalid. This patch introduces the new parameter `:error_message` on `#let` in order to allow such a feature.

I changed the type of `Let#types` from `Hash` to `Array` and made each element an instance of a new class `TypeWrapper`, which holds `type` as well as other metadata, such as `:name` and `:error_message`. When I first started to implement this feature, I wondered where should I put the custom error message. Then, I came up with the idea of refactoring `Let#types` and including metadata to each element of the collection. I hope this works well.