### PR TITLE
Remove set from rbs_collection.yaml

### DIFF
--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,11 +1,20 @@
 ---
 sources:
-- name: ruby/gem_rbs_collection
+- type: git
+  name: ruby/gem_rbs_collection
+  revision: 7765c1821affc50f5b09fda8fba3a7c9b429b216
   remote: https://github.com/ruby/gem_rbs_collection.git
-  revision: main
   repo_dir: gems
 path: ".gem_rbs_collection"
 gems:
+- name: ast
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 7765c1821affc50f5b09fda8fba3a7c9b429b216
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: csv
   version: '0'
   source:
@@ -14,59 +23,15 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: set
-  version: '0'
-  source:
-    type: stdlib
-- name: time
-  version: '0'
-  source:
-    type: stdlib
-- name: activesupport
-  version: '7.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: a68b00d6f36a21875d79e5daf7e396229f411cd6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: ast
-  version: '2.4'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: a68b00d6f36a21875d79e5daf7e396229f411cd6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: fileutils
-  version: '0'
-  source:
-    type: stdlib
-- name: i18n
-  version: '1.10'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: a68b00d6f36a21875d79e5daf7e396229f411cd6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: json
   version: '0'
   source:
     type: stdlib
-- name: listen
-  version: '3.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: a68b00d6f36a21875d79e5daf7e396229f411cd6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: logger
+- name: minitest
   version: '0'
   source:
     type: stdlib
-- name: minitest
+- name: mutex_m
   version: '0'
   source:
     type: stdlib
@@ -75,7 +40,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: a68b00d6f36a21875d79e5daf7e396229f411cd6
+    revision: 7765c1821affc50f5b09fda8fba3a7c9b429b216
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -83,30 +48,10 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: a68b00d6f36a21875d79e5daf7e396229f411cd6
+    revision: 7765c1821affc50f5b09fda8fba3a7c9b429b216
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: securerandom
-  version: '0'
-  source:
-    type: stdlib
-- name: strscan
-  version: '0'
-  source:
-    type: stdlib
-- name: date
-  version: '0'
-  source:
-    type: stdlib
-- name: monitor
-  version: '0'
-  source:
-    type: stdlib
-- name: mutex_m
-  version: '0'
-  source:
-    type: stdlib
-- name: singleton
+- name: time
   version: '0'
   source:
     type: stdlib

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -11,7 +11,6 @@ path: .gem_rbs_collection
 gems:
   - name: csv
   - name: forwardable
-  - name: set
   - name: time
   - name: strong_csv
     ignore: true


### PR DESCRIPTION
Since Ruby 3.2, `set` is availabe out of the box.