### PR TITLE
Use #map directly on an instance of CSV

### DIFF
--- a/lib/strong_csv.rb
+++ b/lib/strong_csv.rb
@@ -62,7 +62,7 @@ class StrongCSV
         yield Row.new(row: row, types: @let.types, lineno: csv.lineno)
       end
     else
-      csv.each.map { |row| Row.new(row: row, types: @let.types, lineno: csv.lineno) }
+      csv.map { |row| Row.new(row: row, types: @let.types, lineno: csv.lineno) }
     end
   end
 end


### PR DESCRIPTION
`CSV` includes `Enumerable`, so we can call `#map` directly on an instance of `CSV`.

This patch just replaces `each.map` with `map`.