### PR TITLE
Add forwardable as a dependency

### DIFF
--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -89,10 +89,6 @@ gems:
     revision: c34ed02f870fb02571f664062eb13ef507702029
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: strscan
-  version: '0'
-  source:
-    type: stdlib
 - name: time
   version: '0'
   source:

--- a/strong_csv.gemspec
+++ b/strong_csv.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.5.5" # rubocop:disable Gemspec/RequiredRubyVersion
   spec.add_dependency "csv"
+  spec.add_dependency "forwardable"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
This pull request includes a minor change to the `strong_csv.gemspec` file to add a new dependency.

Dependency updates:

* [`strong_csv.gemspec`](diffhunk://#diff-b81a33d6271301df2a10f8d51c7c99db0552b9b10add8ffdf3114a6d1cae1dafR17): Added `forwardable` as a dependency.

I wanted to use Steep for this repository, and it would be useful to declare `forwardable` as a dependency to resolve the RBS type definitions.