### PR TITLE
fix: Use client ID for app token workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Update the GitHub App token creation step in the release workflow to use the recommended `client-id` input.

## Purpose

Remove the deprecation warning emitted by `actions/create-github-app-token@v3` for the legacy `app-id` input.

## Background

`actions/create-github-app-token@v3` now recommends the GitHub App Client ID via `client-id`. The repository variable `APP_CLIENT_ID` is already configured, so the release workflow can move away from the deprecated numeric App ID input.

## Changes

Replace `app-id: ${{ vars.APP_ID }}` with `client-id: ${{ vars.APP_CLIENT_ID }}` in `.github/workflows/release.yml`.

The existing private key secret remains unchanged.

## Out of Scope

No action version bumps or private key changes are included.

## Related

- https://github.com/yykamei/block-merge-based-on-time/pull/3059 applied the same `app-id` to `client-id` migration in another repository.

## Testing

- Verified no `app-id` or `APP_ID` references remain in `.github/workflows`.
- Verified `.github/workflows/release.yml` now references `client-id: ${{ vars.APP_CLIENT_ID }}`.
- Ran local self-review via the `code-reviewer` agent; no Critical Issues, Warnings, or Suggestions were reported.

## Post-Release Verification

Confirm the next affected release workflow run no longer emits the `app-id` deprecation warning and that the app token step succeeds.

## Operational Notes

`vars.APP_CLIENT_ID` must remain set to the GitHub App Client ID. Labels, reviewers, and assignees are intentionally left unset.
